### PR TITLE
stroke active tab border color

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -129,7 +129,7 @@ atom-pane .tab-bar .tab.active {
   z-index: 1;
   background: fade(@level-3-bg, 60%);
   min-width: @tab-min-width;
-  border-color: @stroke;
+  border-color: @stroke !important;
   .title {
     padding-right: 20px; //overrule default
   }


### PR DESCRIPTION
The `@stroke` color does not seem to be applied to the active tab border as desired, making the active tab hard to pick out visually.

**Before:** (｀_´)ゞ
<img width="376" alt="before" src="https://cloud.githubusercontent.com/assets/1903876/9615140/fb2da9ee-50bb-11e5-8749-f92df0463ba1.png">

**After:** (´⊙ω⊙`)！
<img width="305" alt="after" src="https://cloud.githubusercontent.com/assets/1903876/9615139/fb2098a8-50bb-11e5-965c-90f7a420d786.png">
